### PR TITLE
Fix last7 helper to return Filters-compliant keys

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import TxTable from './components/TxTable'
 import TopCallers from './components/TopCallers'
 import MethodsHeatmap from './components/MethodsHeatmap'
 
-const last7=()=>{ const to=new Date(), from=new Date(Date.now()-7*24*3600*1000); return {from:from.toISOString().slice(0,10), to:to.toISOString().slice(0,10)} }
+const last7=()=>{ const to=new Date(), from=new Date(Date.now()-7*24*3600*1000); return {fromDate:from.toISOString().slice(0,10), toDate:to.toISOString().slice(0,10)} }
 
 export default function App(){
   const [filters,setFilters]=useState<Filters>({ address:'', network:'mainnet', ...last7(), type:'ALL', status:'ALL' })


### PR DESCRIPTION
## Summary
- update the last7 helper in App.tsx to return fromDate/toDate keys to align with Filters

## Testing
- npm test *(fails: missing @vitejs/plugin-react required by vite.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb91cf6ac832f98cec05a01278a7e