### PR TITLE
Include Vite client types in TypeScript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "vite/client"]
   },
   "include": ["src","vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- include the Vite client type declarations alongside existing Vitest globals in tsconfig

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ceb98949b0832fa95eb10ca50d3d48