### PR TITLE
Use block number RPC call

### DIFF
--- a/src/lib/starknetClient.ts
+++ b/src/lib/starknetClient.ts
@@ -15,8 +15,7 @@ export interface FetchResult { rows: TxRow[]; totalEstimated?: number }
 export async function fetchInteractions(p: FetchParams): Promise<FetchResult> {
   const provider = new RpcProvider({ nodeUrl: RPCS[p.network] })
   const rows: TxRow[] = []
-  const latestInfo = await provider.getBlockHashAndNumber()
-  const latest = latestInfo.block_number
+  const latest = await provider.getBlockNumber()
   const lookback = 400
 
   for (let n = latest; n >= Math.max(0, latest - lookback); n--) {


### PR DESCRIPTION
## Summary
- switch fetchInteractions to use getBlockNumber instead of getBlockHashAndNumber
- simplify the latest block retrieval logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ceba0afd04832f96c7529c634d0b31