### PR TITLE
Update Starknet RPC defaults to v0_8

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ VITE_DATA_MODE=live pnpm dev
 Opcjonalne env:
 - `VITE_STARKNET_RPC_MAINNET`
 - `VITE_STARKNET_RPC_SEPOLIA`
+
+Domyślne publiczne endpointy oraz własne adresy w zmiennych środowiskowych powinny wskazywać na Starknet JSON-RPC w wersji co najmniej `v0_8` (np. `/rpc/v0_8`).

--- a/src/lib/starknetClient.ts
+++ b/src/lib/starknetClient.ts
@@ -2,8 +2,8 @@ import { RpcProvider } from 'starknet'
 import { TxRow, Network, TxStatus, TxType } from '../types'
 
 const RPCS: Record<Network, string> = {
-  mainnet: import.meta.env.VITE_STARKNET_RPC_MAINNET || 'https://starknet-mainnet.public.blastapi.io/rpc/v0_7',
-  sepolia: import.meta.env.VITE_STARKNET_RPC_SEPOLIA || 'https://starknet-sepolia.public.blastapi.io/rpc/v0_7'
+  mainnet: import.meta.env.VITE_STARKNET_RPC_MAINNET || 'https://starknet-mainnet.public.blastapi.io/rpc/v0_8',
+  sepolia: import.meta.env.VITE_STARKNET_RPC_SEPOLIA || 'https://starknet-sepolia.public.blastapi.io/rpc/v0_8'
 }
 
 export interface FetchParams {


### PR DESCRIPTION
## Summary
- update default Starknet mainnet and sepolia RPC endpoints to target the v0_8 API
- note in the README that custom RPC URLs must point to a Starknet JSON-RPC endpoint at least v0_8

## Testing
- npm test *(fails: missing optional dev dependency @vitejs/plugin-react in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cebd392d5c832f9acbc0d1ec9b65d8