### PR TITLE
Add activity logging panel to App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Filters, Network, TxRow } from './types'
+import { Filters, Network, TxRow, ActivityLogEntry } from './types'
 import { fetchInteractions } from './lib/starknetClient'
 import { kpis, methodCounts, topCallers } from './lib/aggregations'
 import KpiCards from './components/KpiCards'
 import TxTable from './components/TxTable'
 import TopCallers from './components/TopCallers'
 import MethodsHeatmap from './components/MethodsHeatmap'
+import ActivityPanel from './components/ActivityPanel'
 
 const last7=()=>{ const to=new Date(), from=new Date(Date.now()-7*24*3600*1000); return {fromDate:from.toISOString().slice(0,10), toDate:to.toISOString().slice(0,10)} }
 
@@ -13,16 +14,33 @@ export default function App(){
   const [filters,setFilters]=useState<Filters>({ address:'', network:'mainnet', ...last7(), type:'ALL', status:'ALL' })
   const [page,setPage]=useState(1); const pageSize=50
   const [rows,setRows]=useState<TxRow[]>([]); const [total,setTotal]=useState<number|undefined>(); const [loading,setLoading]=useState(false); const [error,setError]=useState<string|null>(null)
+  const [logs,setLogs]=useState<ActivityLogEntry[]>([])
+  const [panelOpen,setPanelOpen]=useState(false)
+  const [lastError,setLastError]=useState<string|null>(null)
+
+  const appendLog=(entry:Omit<ActivityLogEntry,'id'>)=>{
+    setLogs(prev=>[...prev,{...entry,id:`${entry.timestamp}-${Math.random().toString(36).slice(2,8)}` }])
+  }
 
   async function load(targetPage:number, reset=false){
     if(!filters.address) return
-    setLoading(true); setError(null)
+    setLoading(true); setError(null); setPanelOpen(true)
+    const startMessage=reset?'Start: rozpoczynam odświeżone ładowanie danych.':`Start: pobieram stronę ${targetPage}.`
+    appendLog({ level:'info', message:startMessage, timestamp:Date.now() })
     try{
       const fromSec=Math.floor(new Date(filters.fromDate).getTime()/1000)
       const toSec=Math.floor(new Date(filters.toDate).getTime()/1000)+86399
       const { rows:r, totalEstimated } = await fetchInteractions({ address:filters.address, network:filters.network, from:fromSec, to:toSec, page:targetPage, pageSize, filters:{ type:filters.type==='ALL'?undefined:filters.type, method:filters.method||undefined, status:filters.status==='ALL'?undefined:filters.status, minFee:filters.minFee, maxFee:filters.maxFee } })
       setRows(prev=> reset? r : [...prev, ...r]); setTotal(totalEstimated)
-    }catch(e:any){ setError(e?.message||'Load failed') } finally{ setLoading(false) }
+      appendLog({ level:'info', message:`Sukces: pobrano ${r.length} rekordów.`, timestamp:Date.now() })
+      setLastError(null)
+    }catch(e:any){
+      const message=e?.message||'Load failed'
+      setError(message)
+      setLastError(message)
+      appendLog({ level:'error', message:`Błąd: ${message}`, timestamp:Date.now() })
+      setPanelOpen(true)
+    } finally{ setLoading(false) }
   }
 
   useEffect(()=>{ setPage(1) },[filters.address,filters.network,filters.fromDate,filters.toDate])
@@ -62,11 +80,17 @@ export default function App(){
         <MethodsHeatmap items={methods}/>
       </section>
       <section className="md:col-span-3 space-y-4">
-        {error && <div className="p-3 rounded-lg bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 flex items-center justify-between"><span>{error}</span><button onClick={()=>load(page)} className="px-3 py-1 rounded bg-red-100 dark:bg-red-800">Spróbuj ponownie</button></div>}
+        {error && (
+          <div className="flex items-center justify-between rounded-lg border border-red-200 dark:border-red-800 bg-red-50/60 dark:bg-red-900/20 px-3 py-2 text-red-700 dark:text-red-300">
+            <span className="text-sm">Wystąpił błąd podczas ładowania.</span>
+            <button onClick={()=>setPanelOpen(true)} className="text-sm font-medium underline">Pokaż log</button>
+          </div>
+        )}
         <div className="rounded-2xl border border-slate-200 dark:border-slate-800"><TxTable rows={rows}/></div>
         {!loading && rows.length>0 && <div className="flex justify-center py-4"><button onClick={()=>{ const next=page+1; setPage(next); load(next) }} className="px-4 py-2 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700">Load more</button></div>}
         {loading && <div className="text-sm text-slate-500">Loading…</div>}
       </section>
     </main>
+    <ActivityPanel open={panelOpen} logs={logs} lastError={lastError} onClose={()=>setPanelOpen(false)}/>
   </div>)
 }

--- a/src/components/ActivityPanel.tsx
+++ b/src/components/ActivityPanel.tsx
@@ -1,0 +1,39 @@
+import { ActivityLogEntry } from '../types'
+
+type ActivityPanelProps = {
+  open:boolean
+  logs:ActivityLogEntry[]
+  lastError:string|null
+  onClose:()=>void
+}
+
+export default function ActivityPanel({ open, logs, lastError, onClose }:ActivityPanelProps){
+  if(!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 p-4">
+      <div className="w-full max-w-2xl rounded-2xl bg-white dark:bg-slate-900 shadow-xl border border-slate-200 dark:border-slate-800">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-slate-200 dark:border-slate-800">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Activity log</h2>
+          <button onClick={onClose} className="text-sm text-slate-500 hover:text-slate-800 dark:hover:text-slate-200">Close</button>
+        </div>
+        <div className="max-h-96 overflow-y-auto px-5 py-4 space-y-3 text-sm">
+          {logs.length===0 && <p className="text-slate-500">No activity yet.</p>}
+          {logs.map(entry=> (
+            <div key={entry.id} className="flex items-start gap-3">
+              <span className={`mt-0.5 h-2.5 w-2.5 rounded-full ${entry.level==='error'?'bg-red-500':'bg-emerald-500'}`}></span>
+              <div>
+                <p className="font-medium text-slate-900 dark:text-slate-100">{new Date(entry.timestamp).toLocaleTimeString()} – {entry.message}</p>
+                <p className="text-xs text-slate-500">{entry.level.toUpperCase()}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="border-t border-slate-200 dark:border-slate-800 px-5 py-4 space-y-2">
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Last error</h3>
+          <p className="text-sm text-slate-500 break-words">{lastError ?? 'No errors recorded.'}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,3 +3,10 @@ export type TxType = 'INVOKE' | 'DECLARE' | 'DEPLOY' | 'L1_HANDLER'
 export type TxStatus = 'ACCEPTED' | 'REJECTED'
 export interface TxRow { timestamp:number; txHash:string; type:TxType; entrypoint?:string; caller:string; to:string; fee:number; status:TxStatus; network:Network }
 export interface Filters { address:string; network:Network; fromDate:string; toDate:string; type?:TxType|'ALL'; method?:string; status?:TxStatus|'ALL'; minFee?:number; maxFee?:number }
+
+export type ActivityLogEntry = {
+  id:string
+  level:'info'|'error'
+  message:string
+  timestamp:number
+}


### PR DESCRIPTION
## Summary
- add an activity log entry type for describing loader events
- implement an activity panel modal to review log messages and last error details
- integrate logging and panel controls into the app load flow, recording start/success/error events

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cecd66aa9c832f94da106a842352ee