### PR TITLE
Add RPC retry handling and activity logging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Filters, Network, TxRow, ActivityLogEntry } from './types'
+import { Filters, Network, TxRow, ActivityLogEntry, ActivityLogLevel } from './types'
 import { fetchInteractions } from './lib/starknetClient'
 import { kpis, methodCounts, topCallers } from './lib/aggregations'
 import KpiCards from './components/KpiCards'
@@ -21,6 +21,9 @@ export default function App(){
   const appendLog=(entry:Omit<ActivityLogEntry,'id'>)=>{
     setLogs(prev=>[...prev,{...entry,id:`${entry.timestamp}-${Math.random().toString(36).slice(2,8)}` }])
   }
+  const logWithTimestamp=(entry:{ level:ActivityLogLevel; message:string })=>{
+    appendLog({ ...entry, timestamp:Date.now() })
+  }
 
   async function load(targetPage:number, reset=false){
     if(!filters.address) return
@@ -30,7 +33,7 @@ export default function App(){
     try{
       const fromSec=Math.floor(new Date(filters.fromDate).getTime()/1000)
       const toSec=Math.floor(new Date(filters.toDate).getTime()/1000)+86399
-      const { rows:r, totalEstimated } = await fetchInteractions({ address:filters.address, network:filters.network, from:fromSec, to:toSec, page:targetPage, pageSize, filters:{ type:filters.type==='ALL'?undefined:filters.type, method:filters.method||undefined, status:filters.status==='ALL'?undefined:filters.status, minFee:filters.minFee, maxFee:filters.maxFee } })
+      const { rows:r, totalEstimated } = await fetchInteractions({ address:filters.address, network:filters.network, from:fromSec, to:toSec, page:targetPage, pageSize, filters:{ type:filters.type==='ALL'?undefined:filters.type, method:filters.method||undefined, status:filters.status==='ALL'?undefined:filters.status, minFee:filters.minFee, maxFee:filters.maxFee }, log:logWithTimestamp })
       setRows(prev=> reset? r : [...prev, ...r]); setTotal(totalEstimated)
       appendLog({ level:'info', message:`Sukces: pobrano ${r.length} rekordów.`, timestamp:Date.now() })
       setLastError(null)

--- a/src/components/ActivityPanel.tsx
+++ b/src/components/ActivityPanel.tsx
@@ -19,15 +19,23 @@ export default function ActivityPanel({ open, logs, lastError, onClose }:Activit
         </div>
         <div className="max-h-96 overflow-y-auto px-5 py-4 space-y-3 text-sm">
           {logs.length===0 && <p className="text-slate-500">No activity yet.</p>}
-          {logs.map(entry=> (
-            <div key={entry.id} className="flex items-start gap-3">
-              <span className={`mt-0.5 h-2.5 w-2.5 rounded-full ${entry.level==='error'?'bg-red-500':'bg-emerald-500'}`}></span>
-              <div>
-                <p className="font-medium text-slate-900 dark:text-slate-100">{new Date(entry.timestamp).toLocaleTimeString()} – {entry.message}</p>
-                <p className="text-xs text-slate-500">{entry.level.toUpperCase()}</p>
+          {logs.map(entry=> {
+            const color = entry.level==='error'
+              ? 'bg-red-500'
+              : entry.level==='warn'
+                ? 'bg-amber-500'
+                : 'bg-emerald-500'
+
+            return (
+              <div key={entry.id} className="flex items-start gap-3">
+                <span className={`mt-0.5 h-2.5 w-2.5 rounded-full ${color}`}></span>
+                <div>
+                  <p className="font-medium text-slate-900 dark:text-slate-100">{new Date(entry.timestamp).toLocaleTimeString()} – {entry.message}</p>
+                  <p className="text-xs text-slate-500">{entry.level.toUpperCase()}</p>
+                </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
         <div className="border-t border-slate-200 dark:border-slate-800 px-5 py-4 space-y-2">
           <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Last error</h3>

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,9 +4,11 @@ export type TxStatus = 'ACCEPTED' | 'REJECTED'
 export interface TxRow { timestamp:number; txHash:string; type:TxType; entrypoint?:string; caller:string; to:string; fee:number; status:TxStatus; network:Network }
 export interface Filters { address:string; network:Network; fromDate:string; toDate:string; type?:TxType|'ALL'; method?:string; status?:TxStatus|'ALL'; minFee?:number; maxFee?:number }
 
+export type ActivityLogLevel = 'info' | 'warn' | 'error'
+
 export type ActivityLogEntry = {
   id:string
-  level:'info'|'error'
+  level:ActivityLogLevel
   message:string
   timestamp:number
 }


### PR DESCRIPTION
## Summary
- add a shared RPC retry helper with 429 detection, backoff handling, and shared logging used by all fetchInteractions StarkNet calls
- extend fetchInteractions and the activity log plumbing to capture retry warnings/errors and support a warn log level in the UI
- cover the new retry behaviour with Vitest unit tests for both successful retries and exhausted attempts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cedc91d780832fa170c91551ed5be6