### PR TITLE
Add shared RPC rate limiter and expose config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ VITE_DATA_MODE=live pnpm dev
 Opcjonalne env:
 - `VITE_STARKNET_RPC_MAINNET`
 - `VITE_STARKNET_RPC_SEPOLIA`
+- `VITE_RPC_REQUESTS_PER_SECOND` (domyślnie 3)
+- `VITE_RPC_MAX_CONCURRENCY` (domyślnie 2)
 
 Domyślne publiczne endpointy oraz własne adresy w zmiennych środowiskowych powinny wskazywać na Starknet JSON-RPC w wersji co najmniej `v0_8` (np. `/rpc/v0_8`).


### PR DESCRIPTION
## Summary
- add a shared async RPC rate limiter with configurable throughput and concurrency
- route all Starknet provider calls in `fetchInteractions` through the limiter and emit throttle logs
- document the new environment variables for limiter tuning in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cedfd1dad8832f9deb016a3195d465