### PR TITLE
feat: add configurable RPC retry timeout

### DIFF
--- a/src/lib/starknetClient.test.ts
+++ b/src/lib/starknetClient.test.ts
@@ -261,7 +261,11 @@ describe('fetchInteractions rate limit handling', () => {
 
       expect(result.rows).toHaveLength(0)
       expect(getEvents).toHaveBeenCalledTimes(3)
-      expect(warnLogs.filter((entry) => entry.level === 'warn')).toHaveLength(2)
+      expect(
+        warnLogs.filter(
+          (entry) => entry.level === 'warn' && entry.message.includes('Rate limited')
+        )
+      ).toHaveLength(2)
     } finally {
       vi.useRealTimers()
     }


### PR DESCRIPTION
## Summary
- replace the hard-coded RPC retry count with a configurable timeout and expose it through VITE_RPC_RETRY_TIMEOUT_MS
- keep retrying until the accumulated delay would exceed the budget and log an error when the budget or attempt limit is reached
- update the rate-limit test to assert only the rate-limit warnings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cee1bffc98832f85f905632b4bf99a