### PR TITLE
feat: add configurable RPC retry budget

### DIFF
--- a/src/lib/starknetClient.test.ts
+++ b/src/lib/starknetClient.test.ts
@@ -261,7 +261,10 @@ describe('fetchInteractions rate limit handling', () => {
 
       expect(result.rows).toHaveLength(0)
       expect(getEvents).toHaveBeenCalledTimes(3)
-      expect(warnLogs.filter((entry) => entry.level === 'warn')).toHaveLength(2)
+      const rateLimitLogs = warnLogs.filter(
+        (entry) => entry.level === 'warn' && entry.message.includes('Rate limited')
+      )
+      expect(rateLimitLogs).toHaveLength(2)
     } finally {
       vi.useRealTimers()
     }
@@ -316,7 +319,10 @@ describe('fetchInteractions rate limit handling', () => {
 
       await expectation
       expect(getEvents.mock.calls.length).toBeGreaterThan(1)
-      expect(errorLogs.some((entry) => entry.level === 'error')).toBe(true)
+      const exhaustedLog = errorLogs.find(
+        (entry) => entry.level === 'error' && entry.message.includes('Retry budget exhausted')
+      )
+      expect(exhaustedLog).toBeTruthy()
     } finally {
       vi.useRealTimers()
     }


### PR DESCRIPTION
## Summary
- add configurable retry budget for RPC calls and log when the budget is exhausted
- respect retry budget in callRpcWithRetry and expose configuration through Vite env
- update rate-limit handling tests to reflect new logging behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cee9299624832fbc397f1cb0c98de0